### PR TITLE
[calander-management-app] Add public index for React build

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <title>Calendar Management App</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a missing `public/index.html` so React can build

## Testing
- `npm run build` *(fails: unable to connect to npm registry)*