### PR TITLE
[calander-management-app] Add CORS middleware

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, Depends, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from datetime import datetime
@@ -11,6 +12,14 @@ from . import crud, models, schemas
 Base.metadata.create_all(bind=engine)
 
 app = FastAPI()
+
+# Enable CORS so the React frontend can communicate with the API
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 


### PR DESCRIPTION
## Summary
- allow cross-origin requests from frontend by enabling CORSMiddleware

## Testing
- `docker-compose up --build -d` *(fails: `docker-compose: command not found`)*
- `docker compose up --build -d` *(fails: `docker: command not found`)*