### PR TITLE
[calander-management-app] Include profile relations in /me response

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -72,7 +72,7 @@ def create_customer_appointment(customer_id: int, specialist_id: int, time: date
         raise HTTPException(status_code=400, detail="Specialist not assigned to customer")
     return crud.create_appointment(db, customer_id, specialist_id, time)
 
-@app.get("/me", response_model=schemas.User)
+@app.get("/me", response_model=schemas.UserProfile)
 def read_me(current: models.User = Depends(get_current_user)):
     return current
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pydantic import BaseModel
 from typing import Optional, List
 from datetime import datetime
@@ -15,6 +17,23 @@ class User(UserBase):
 
     class Config:
         orm_mode = True
+
+class CustomerInfo(BaseModel):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+class SpecialistInfo(BaseModel):
+    id: int
+    working_hours: str
+
+    class Config:
+        orm_mode = True
+
+class UserProfile(User):
+    customer: Optional[CustomerInfo] = None
+    specialist: Optional[SpecialistInfo] = None
 
 class Customer(BaseModel):
     id: int


### PR DESCRIPTION
## Summary
- extend API schema with UserProfile including customer/specialist info
- update `/me` endpoint to return UserProfile

## Testing
- `flake8` *(fails: command not found)*