### PR TITLE
[calander-management-app] Add calendar navigation and event modal

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -1,4 +1,4 @@
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 from . import models
 from . import schemas
 from datetime import datetime
@@ -61,8 +61,14 @@ def create_weekly_plan(db: Session, customer_id: int, description: str):
     return plan
 
 
-def create_appointment(db: Session, customer_id: int, specialist_id: int, time: datetime):
-    appt = models.Appointment(customer_id=customer_id, specialist_id=specialist_id, time=time)
+def create_appointment(db: Session, customer_id: int, specialist_id: int, time: datetime, end_time: datetime, title: str):
+    appt = models.Appointment(
+        customer_id=customer_id,
+        specialist_id=specialist_id,
+        time=time,
+        end_time=end_time,
+        title=title,
+    )
     db.add(appt)
     db.commit()
     db.refresh(appt)
@@ -86,6 +92,7 @@ def verify_password(plain: str, hashed: str) -> bool:
 def get_specialist_appointments(db: Session, specialist_id: int) -> List[models.Appointment]:
     return (
         db.query(models.Appointment)
+        .options(joinedload(models.Appointment.customer).joinedload(models.Customer.user))
         .filter(models.Appointment.specialist_id == specialist_id)
         .all()
     )
@@ -94,6 +101,7 @@ def get_specialist_appointments(db: Session, specialist_id: int) -> List[models.
 def get_customer_appointments(db: Session, customer_id: int) -> List[models.Appointment]:
     return (
         db.query(models.Appointment)
+        .options(joinedload(models.Appointment.specialist).joinedload(models.Specialist.user))
         .filter(models.Appointment.customer_id == customer_id)
         .all()
     )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -62,7 +62,15 @@ def create_plan(customer_id: int, description: str, db: Session = Depends(get_db
     return crud.create_weekly_plan(db, customer_id, description)
 
 @app.post("/customers/{customer_id}/appointments")
-def create_customer_appointment(customer_id: int, specialist_id: int, time: datetime, db: Session = Depends(get_db), current: models.User = Depends(get_current_user)):
+def create_customer_appointment(
+    customer_id: int,
+    specialist_id: int,
+    time: datetime,
+    end_time: datetime,
+    title: str,
+    db: Session = Depends(get_db),
+    current: models.User = Depends(get_current_user),
+):
     if current.type != models.UserType.customer or current.customer.id != customer_id:
         raise HTTPException(status_code=403, detail="Not authorized")
     if time < datetime.utcnow():
@@ -70,7 +78,9 @@ def create_customer_appointment(customer_id: int, specialist_id: int, time: date
     specialists = crud.get_customer_specialists(db, customer_id)
     if not any(s.id == specialist_id for s in specialists):
         raise HTTPException(status_code=400, detail="Specialist not assigned to customer")
-    return crud.create_appointment(db, customer_id, specialist_id, time)
+    if end_time <= time:
+        raise HTTPException(status_code=400, detail="End time must be after start time")
+    return crud.create_appointment(db, customer_id, specialist_id, time, end_time, title)
 
 @app.get("/me", response_model=schemas.UserProfile)
 def read_me(current: models.User = Depends(get_current_user)):

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -25,6 +25,7 @@ class Customer(Base):
 
     user = relationship("User", back_populates="customer")
     weekly_plans = relationship("WeeklyPlan", back_populates="customer")
+    appointments = relationship("Appointment", back_populates="customer")
 
 class Specialist(Base):
     __tablename__ = "specialists"
@@ -50,8 +51,11 @@ class Appointment(Base):
     specialist_id = Column(Integer, ForeignKey("specialists.id"))
     customer_id = Column(Integer, ForeignKey("customers.id"))
     time = Column(DateTime)
+    end_time = Column(DateTime)
+    title = Column(String)
 
     specialist = relationship("Specialist", back_populates="appointments")
+    customer = relationship("Customer", back_populates="appointments")
 
 class WeeklyPlan(Base):
     __tablename__ = "weekly_plans"

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -53,6 +53,11 @@ class Specialist(BaseModel):
 class Appointment(BaseModel):
     id: int
     time: datetime
+    end_time: datetime
+    title: Optional[str] = None
+    customer_id: int
+    specialist_id: int
+    customer: Optional[Customer] = None
 
     class Config:
         orm_mode = True

--- a/frontend/src/CustomerDashboard.js
+++ b/frontend/src/CustomerDashboard.js
@@ -41,8 +41,14 @@ function CustomerDashboard({ user, onLogout }) {
     setSpecAppointments(data);
   };
 
-  const handleSlotSelect = async (dateTime) => {
-    await createAppointment(user.customer.id, selectedSpec, dateTime);
+  const handleSlotSelect = async ({ start, end, title }) => {
+    await createAppointment(
+      user.customer.id,
+      selectedSpec,
+      start,
+      end,
+      title
+    );
     loadData();
     loadSpecAppointments(selectedSpec);
   };
@@ -100,7 +106,9 @@ function CustomerDashboard({ user, onLogout }) {
 export default CustomerDashboard;
 
 function MonthlyCalendar({ appointments, onSelect }) {
-  const [current] = useState(new Date());
+  const [current, setCurrent] = useState(new Date());
+  const [selectedDate, setSelectedDate] = useState(null);
+  const [form, setForm] = useState({ title: '', start: '09:00', end: '10:00' });
 
   const start = new Date(current.getFullYear(), current.getMonth(), 1);
   const daysInMonth = new Date(current.getFullYear(), current.getMonth() + 1, 0).getDate();
@@ -118,24 +126,35 @@ function MonthlyCalendar({ appointments, onSelect }) {
     weeks.push(dates.slice(i, i + 7));
   }
 
-  const handleClick = (date) => {
-    const time = prompt('Enter time (HH:MM)');
-    if (!time) return;
-    const dt = `${date.toISOString().slice(0, 10)}T${time}`;
-    if (new Date(dt) < new Date()) {
-      alert('Cannot book in the past');
-      return;
+  const timeOptions = [];
+  for (let h = 0; h < 24; h++) {
+    for (let m = 0; m < 60; m += 30) {
+      const hh = h.toString().padStart(2, '0');
+      const mm = m.toString().padStart(2, '0');
+      timeOptions.push(`${hh}:${mm}`);
     }
-    const conflict = appointments.some((a) => a.time === dt);
-    if (conflict) {
-      alert('Slot already booked');
-      return;
-    }
-    onSelect(dt);
+  }
+
+  const openModal = (date) => {
+    setSelectedDate(date);
+    setForm({ title: '', start: '09:00', end: '10:00' });
+  };
+
+  const create = () => {
+    const day = selectedDate.toISOString().slice(0, 10);
+    const startISO = `${day}T${form.start}`;
+    const endISO = `${day}T${form.end}`;
+    onSelect({ start: startISO, end: endISO, title: form.title });
+    setSelectedDate(null);
   };
 
   return (
     <div>
+      <div className="flex justify-between items-center mb-2">
+        <button className="px-2" onClick={() => setCurrent(new Date(current.getFullYear(), current.getMonth() - 1, 1))}>&lt;</button>
+        <div className="font-semibold">{current.toLocaleString('default', { month: 'long', year: 'numeric' })}</div>
+        <button className="px-2" onClick={() => setCurrent(new Date(current.getFullYear(), current.getMonth() + 1, 1))}>&gt;</button>
+      </div>
       <div className="grid grid-cols-7 text-center font-semibold">
         {['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map((d) => (
           <div key={d} className="border p-1">
@@ -153,11 +172,13 @@ function MonthlyCalendar({ appointments, onSelect }) {
               <div key={j} className="h-24 border p-1 text-xs align-top">
                 <div>{date.getDate()}</div>
                 {daily.map((a) => (
-                  <div key={a.id} className="mt-1 bg-blue-200 rounded px-1">booked</div>
+                  <div key={a.id} className="mt-1 bg-blue-200 rounded px-1 truncate">
+                    {a.title || 'booked'}
+                  </div>
                 ))}
                 <button
                   className="text-primary underline text-xs mt-1"
-                  onClick={() => handleClick(date)}
+                  onClick={() => openModal(date)}
                 >
                   +
                 </button>
@@ -166,6 +187,44 @@ function MonthlyCalendar({ appointments, onSelect }) {
           })}
         </div>
       ))}
+
+      {selectedDate && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+          <div className="bg-white p-4 rounded space-y-2 w-64">
+            <div className="font-semibold mb-2">Create Event {selectedDate.toDateString()}</div>
+            <input
+              className="w-full border border-gray-300 rounded p-1"
+              placeholder="Title"
+              value={form.title}
+              onChange={(e) => setForm({ ...form, title: e.target.value })}
+            />
+            <div className="flex space-x-2">
+              <select
+                className="border border-gray-300 rounded p-1 flex-1"
+                value={form.start}
+                onChange={(e) => setForm({ ...form, start: e.target.value })}
+              >
+                {timeOptions.map((t) => (
+                  <option key={t} value={t}>{t}</option>
+                ))}
+              </select>
+              <select
+                className="border border-gray-300 rounded p-1 flex-1"
+                value={form.end}
+                onChange={(e) => setForm({ ...form, end: e.target.value })}
+              >
+                {timeOptions.map((t) => (
+                  <option key={t} value={t}>{t}</option>
+                ))}
+              </select>
+            </div>
+            <div className="flex justify-end space-x-2">
+              <button className="px-2" onClick={() => setSelectedDate(null)}>Cancel</button>
+              <button className="bg-primary text-white px-2 rounded" onClick={create}>Save</button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/SpecialistDashboard.js
+++ b/frontend/src/SpecialistDashboard.js
@@ -23,7 +23,10 @@ function SpecialistDashboard({ user, onLogout }) {
         <h3 className="font-semibold mb-2">Appointments</h3>
         <ul className="space-y-1">
           {appointments.map((a) => (
-            <li key={a.id}>{new Date(a.time).toLocaleString()}</li>
+            <li key={a.id}>
+              {new Date(a.time).toLocaleString()} -{' '}
+              {a.customer?.user.username} ({a.title})
+            </li>
           ))}
         </ul>
       </section>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -75,9 +75,11 @@ export async function getSpecialistAppointments(specialistId) {
   return response.data;
 }
 
-export async function createAppointment(customerId, specialistId, time) {
+export async function createAppointment(customerId, specialistId, time, endTime, title) {
   const url = `/customers/${customerId}/appointments`;
-  const response = await api.post(url, null, { params: { specialist_id: specialistId, time } });
+  const response = await api.post(url, null, {
+    params: { specialist_id: specialistId, time, end_time: endTime, title },
+  });
   return response.data;
 }
 


### PR DESCRIPTION
## Summary
- support monthly appointment view navigation
- enable event creation modal with title and time dropdowns
- include appointment details in specialist dashboard
- store appointment title and end time in backend

## Testing
- `npm run build` *(fails: connect EHOSTUNREACH)*
- `python -m py_compile backend/app/*.py`